### PR TITLE
Фикс метода getByCode

### DIFF
--- a/src/Queries/ElementQuery.php
+++ b/src/Queries/ElementQuery.php
@@ -193,7 +193,7 @@ class ElementQuery extends OldCoreQuery
      */
     public function getByCode($code)
     {
-        $this->filter['CODE'] = $code;
+        $this->filter['=CODE'] = $code;
 
         return $this->first();
     }

--- a/src/Queries/SectionQuery.php
+++ b/src/Queries/SectionQuery.php
@@ -129,7 +129,7 @@ class SectionQuery extends OldCoreQuery
      */
     public function getByCode($code)
     {
-        $this->filter['CODE'] = $code;
+        $this->filter['=CODE'] = $code;
 
         return $this->first();
     }


### PR DESCRIPTION
Поле CODE, заменено на =CODE, иначе прочерк в символьном коде фильтруется как "1 любой символ", а так же фильтр срабатывает как LIKE "%CODE%", если не добавлен знак равно.

Маны:
https://dev.1c-bitrix.ru/api_help/iblock/classes/ciblocksection/getlist.php
https://dev.1c-bitrix.ru/api_help/iblock/classes/ciblockelement/getlist.php